### PR TITLE
Pin spdlog to 1.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - omniorb-libs
     - libhdbpp
     - libpqxx =6.4
-    - spdlog >=1.9
+    - spdlog >=1.9,<1.10
 
 test:
   commands:


### PR DESCRIPTION

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

New build of spdlog 1.10 (https://github.com/conda-forge/spdlog-feedstock/pull/50) broke the compilation: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=593854&view=logs&jobId=656edd35-690f-5c53-9ba3-09c10d0bea97

So package was never published.

Pin spdlog to 1.9 for now.
